### PR TITLE
Docker を使った開発環境の立ち上げ

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,18 @@
+FROM ruby:3.0.2-slim
+
+# NOTE: 日本語環境にする
+RUN apt-get update \
+  && apt-get install -y locales \
+  && echo "ja_JP UTF-8" > /etc/locale.gen \
+  && locale-gen
+ENV LANG="ja_JP.UTF-8" \
+    LANGUAGE="ja_JP:ja" \
+    LC_ALL="ja_JP.UTF-8"
+
+# FIXME: build-essential ではなく必要なものだけを入れたい
+RUN apt-get install -y build-essential curl libmariadb-dev git vim
+
+RUN gem install -f bundler
+
+RUN mkdir /app
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # API 専用アプリケーション Rails session_store redis サンプル
+
+API 専用アプリケーション Rails において session_store に直接 Redis を指定するサンプル。
+
+## 環境
+
+`docker-compose` を使って開発環境を立ち上げます。
+
+- Ruby
+  - 3.0.2
+- Rails
+  - 6.1.4.1
+
+### Docker プロセス起動
+
+```bash
+docker-compose up
+# Ctrl+C で終了
+```
+
+### Docker アタッチ
+
+```bash
+docker-compose exec app /bin/bash
+```
+
+### Docker プロセス終了
+
+```bash
+docker-compose rm
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3"
+services:
+  mysql:
+    image: mysql:5.7
+    ports:
+      - 33306:3306
+    volumes:
+      - mysql-data:/var/lib/mysql
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+  redis:
+    image: redis:6.0-alpine
+    ports:
+      - 63799:6379
+  app:
+    build:
+      context: ./
+      dockerfile: Dockerfile.dev
+    command: ./entrypoint.sh
+    tty: true
+    volumes:
+      - .:/app:cached
+      - rails_bundle:/app/vendor
+      - rails_log:/app/log
+      - /app/tmp
+    depends_on:
+      - mysql
+      - redis
+    ports:
+      - 3000:3000
+    environment:
+      PORT: 3000
+      MYSQL_HOST: mysql
+      REDIS_HOST: redis
+volumes:
+  mysql-data:
+  rails_bundle:
+  rails_log:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eux
+
+# NOTE: `A server is already running. Check /app/tmp/pids/server.pid.` の発生を防ぐ
+rm -f /app/tmp/pids/server.pid
+/bin/bash


### PR DESCRIPTION
`docker-compose` を使って開発環境を立ち上げます。
使用しているイメージは `ruby:3.0.2-slim` です。
https://hub.docker.com/layers/ruby/library/ruby/3.0.2-slim/images/sha256-9b99a189ec5bad0876c650ad4a3a5ca711c10c8373192cf6e62ac3ebe2459b1b?context=explore
使い方は README に追記しています。