### PR TITLE
session_store に Redis を使うよう設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem 'bootsnap', '>= 1.4.4', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+gem "redis"
+gem 'redis-actionpack'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,16 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.5.1)
+    redis-actionpack (5.2.0)
+      actionpack (>= 5, < 7)
+      redis-rack (>= 2.1.0, < 3)
+      redis-store (>= 1.1.0, < 2)
+    redis-rack (2.1.3)
+      rack (>= 2.0.8, < 3)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.9.0)
+      redis (>= 4, < 5)
     spring (3.0.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -151,6 +161,8 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   puma (~> 5.0)
   rails (~> 6.1.4, >= 6.1.4.1)
+  redis
+  redis-actionpack
   spring
   tzinfo-data
 

--- a/app/controllers/redis_controller.rb
+++ b/app/controllers/redis_controller.rb
@@ -1,0 +1,10 @@
+class RedisController < ApplicationController
+  def session_set
+    session[:test_time] = Time.current
+    render json: { status: "ok" }
+  end
+
+  def session_get
+    render json: { time: session[:test_time]&.iso8601 }
+  end
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Rails.application.config.middleware.insert_after ActiveRecord::Migration::CheckPending, ActionDispatch::Cookies
+Rails.application.config.middleware.insert_after ActionDispatch::Cookies, ActionDispatch::Session::RedisStore,
+  servers: ["redis://#{ENV.fetch("REDIS_HOST") { "localhost" }}:6379/0"],
+  expire_after: 5.minutes,
+  key: "_redis_sample_session"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resource :redis, only: [] do
+    get "/session_set", to: "redis#session_set"
+    get "/session_get", to: "redis#session_get"
+  end
 end


### PR DESCRIPTION
- `gem 'redis'`
- `gem 'redis-actionpack'`

を追加し、`config/initializers/session_store.rb` にて session_store に関する middleware を追加。
2つのエンドポイント

- http://127.0.0.1:3000/redis/session_set
- http://127.0.0.1:3000/redis/session_get

を生やしてアクセスし、session が Redis に格納される事を確認しました。

<img src="https://user-images.githubusercontent.com/5770071/142764868-d9da8746-55af-4944-8190-39045b3ee90b.png" width="400px" />