### PR TITLE
シングルクォート統一、および README に session 確認用エンドポイント追記

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
-gem "redis"
+gem 'redis'
 gem 'redis-actionpack'
 
 group :development, :test do

--- a/README.md
+++ b/README.md
@@ -37,4 +37,7 @@ docker-compose rm
 bundle exec rails s -b 0.0.0.0 -p $PORT
 ```
 
-http://127.0.0.1:3000
+- http://127.0.0.1:3000/redis/session_set
+  - 現在時刻を session に格納します
+- http://127.0.0.1:3000/redis/session_get
+  - session に格納した時刻を返します


### PR DESCRIPTION
#3 で追加したエンドポイントへのアクセス方法を README に追加しました。
また、Gemfile をシングルクォートで統一したく `gem "redis"` から `gem 'redis'` に変更しています。