### PR TITLE
テスト時にエラーとならないよう `ActionDispatch::Cookies` 挿入場所を変更

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Rails.application.config.middleware.insert_after ActiveRecord::Migration::CheckPending, ActionDispatch::Cookies
+Rails.application.config.middleware.insert_before Rack::Head, ActionDispatch::Cookies
 Rails.application.config.middleware.insert_after ActionDispatch::Cookies, ActionDispatch::Session::RedisStore,
   servers: ["redis://#{ENV.fetch("REDIS_HOST") { "localhost" }}:6379/0"],
   expire_after: 5.minutes,


### PR DESCRIPTION
`RAILS_ENV=test bundle exec rails middleware` を実行すると以下のエラーが出る。

```
RuntimeError:
  No such middleware to insert after: ActiveRecord::Migration::CheckPending
```

`middleware.insert_after` してる箇所をコメントアウトして実施すると、以下の結果を得た。

```
use ActionDispatch::HostAuthorization
use Rack::Sendfile
use ActionDispatch::Static
use ActionDispatch::Executor
use ActiveSupport::Cache::Strategy::LocalCache::Middleware
use Rack::Runtime
use ActionDispatch::RequestId
use ActionDispatch::RemoteIp
use Rails::Rack::Logger
use ActionDispatch::ShowExceptions
use ActionDispatch::DebugExceptions
use ActionDispatch::ActionableExceptions
use ActionDispatch::Reloader
use ActionDispatch::Callbacks
use Rack::Head
use Rack::ConditionalGet
use Rack::ETag
run App::Application.routes
```

テスト時は `ActiveRecord::Migration::CheckPending` が存在しないため、挿入場所を特定できずエラーとなった。
なので `middleware.insert_after ActiveRecord::Migration::CheckPending` ではなく、双方に存在する `Rack::Head` を使って `insert_before Rack::Head` とするよう変更しました。